### PR TITLE
Limit push builds to main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,8 @@ on:
         "00 06 * * *" # build at 06:00 UTC every day
         # (20 minutes after last ublue images start building)
   push:
+    branches:
+      - main
     paths-ignore: # don't rebuild if only documentation has changed
       - "**.md"
 


### PR DESCRIPTION
## Summary
- prevent duplicate CI runs on PRs by limiting push triggers to the main branch

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cdd6a474d48333833fbef7034d5055