### PR TITLE
Preserve Bluefin just recipes before adding custom ones

### DIFF
--- a/files/scripts/preserve-bluefin-justfiles.sh
+++ b/files/scripts/preserve-bluefin-justfiles.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_JUST="/usr/share/ublue-os/just/60-custom.just"
+BACKUP_DIR="/usr/share/bluebuild/upstream-just"
+BACKUP_JUST="${BACKUP_DIR}/bluefin.just"
+IMPORT_LINE='import "/usr/share/bluebuild/upstream-just/bluefin.just"'
+
+if [[ ! -f "${BASE_JUST}" ]]; then
+    echo "Warning: ${BASE_JUST} not found; skipping Bluefin justfile preservation." >&2
+    exit 0
+fi
+
+if grep -Fxq "${IMPORT_LINE}" "${BASE_JUST}"; then
+    echo "Bluefin justfile already preserved; no changes needed."
+    exit 0
+fi
+
+echo "Preserving original Bluefin just recipes and converting ${BASE_JUST} into an import shim."
+install -Dm0644 "${BASE_JUST}" "${BACKUP_JUST}"
+{
+    printf '# Managed by preserve-bluefin-justfiles.sh\n'
+    printf '%s\n' "${IMPORT_LINE}"
+} > "${BASE_JUST}"

--- a/recipes/recipe.yml
+++ b/recipes/recipe.yml
@@ -34,6 +34,7 @@ modules:
 
   - type: script
     scripts:
+      - preserve-bluefin-justfiles.sh
       - install-cursor.sh
       - setup-sunshine.sh
 


### PR DESCRIPTION
## Summary
- add a build script that snapshots the upstream 60-custom.just file and turns it into an import shim
- ensure the recipe runs the preservation script before other scripts so custom justfiles extend the Bluefin set

## Testing
- bash -n files/scripts/preserve-bluefin-justfiles.sh

------
https://chatgpt.com/codex/tasks/task_e_68cef701de5c833390480ce6bbec510a