### PR TITLE
Enable cache for build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,7 @@ jobs:
           recipe: ${{ matrix.recipe }}
           cosign_private_key: ${{ secrets.SIGNING_SECRET }}
           registry_token: ${{ github.token }}
+          use_cache: true
           pr_event_number: ${{ github.event.number }}
 
           # enabled by default, disable if your image is small and you want faster builds


### PR DESCRIPTION
## Summary
- enable the reusable bluebuild action cache in the build workflow

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cf344162e48333a98325955d3d44e5