### PR TITLE
Fix sunshine help usage rendering

### DIFF
--- a/files/justfiles/gaming/sunshine.just
+++ b/files/justfiles/gaming/sunshine.just
@@ -23,14 +23,13 @@ setup-sunshine ACTION="":
     esac
 
     if [[ "${OPTION,,}" == "help" ]]; then
-        cat <<'USAGE'
-Usage: ujust setup-sunshine <option>
-  <option>: Specify the quick option to skip the prompt
-  Use 'enable' to enable the Sunshine service
-  Use 'disable' to disable the Sunshine service
-  Use 'portal' to open the Sunshine management portal
-  Use 'exit' to exit without making changes
-USAGE
+        printf '%s\n' \
+            "Usage: ujust setup-sunshine <option>" \
+            "  <option>: Specify the quick option to skip the prompt" \
+            "  Use 'enable' to enable the Sunshine service" \
+            "  Use 'disable' to disable the Sunshine service" \
+            "  Use 'portal' to open the Sunshine management portal" \
+            "  Use 'exit' to exit without making changes"
         exit 0
     fi
 


### PR DESCRIPTION
## Summary
- replace the sunshine help message heredoc with printf so the recipe parses correctly

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d05f72d4a48333ac8073ebf8d7dd63