### PR TITLE
chore: remove toolbox package

### DIFF
--- a/recipes/recipe.yml
+++ b/recipes/recipe.yml
@@ -33,6 +33,7 @@ modules:
       packages:
         - code
         - thunderbird
+        - toolbox
 
   - type: script
     scripts:


### PR DESCRIPTION
## Summary
- ensure the DNF module removes the toolbox package during image creation

## Testing
- not run (podman is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d43c828840833391bc86eb6932ef5a