### PR TITLE
Add gcc-c++ to DNF package list

### DIFF
--- a/recipes/recipe.yml
+++ b/recipes/recipe.yml
@@ -29,6 +29,7 @@ modules:
         - sunshine
         - steam
         - topgrade
+        - gcc-c++
     remove:
       packages:
         - code


### PR DESCRIPTION
## Summary
- include gcc-c++ in the DNF packages so the image provides the C++ compiler

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e01ccaf1808333950e8b4de1241044