### PR TITLE
fix: disable topgrade mandb step via args

### DIFF
--- a/files/system/usr/bin/topgrade-updater
+++ b/files/system/usr/bin/topgrade-updater
@@ -65,16 +65,12 @@ use_sudo = true
 [containers]
 # Podman is the container runtime shipped with Yamshy OS.
 runtime = "podman"
-
-[mandb]
-# Manual page indices are refreshed automatically in the background service.
-enable = false
 EOF
     config_args=(--config "${cleanup_config}")
   fi
 fi
 
-topgrade_args=(--keep --disable=toolbx)
+topgrade_args=(--keep --disable=toolbx --disable=mandb)
 if [[ "${topgrade_cmd[0]}" == "/usr/bin/topgrade" ]]; then
   topgrade_args+=(--disable=firmware)
 fi


### PR DESCRIPTION
## Summary
- remove the generated mandb table from the temporary topgrade configuration
- add the mandb entry to the list of disabled topgrade steps so it remains skipped

## Testing
- files/system/usr/bin/topgrade-updater --help

------
https://chatgpt.com/codex/tasks/task_e_68e1c54882c08333891bfb3d931892cd